### PR TITLE
Small tweaks to allow for cleaner behavior + Archiving

### DIFF
--- a/Templates/Framework & Library/Static iOS Framework.xctemplate/TemplateInfo.plist
+++ b/Templates/Framework & Library/Static iOS Framework.xctemplate/TemplateInfo.plist
@@ -33,7 +33,7 @@
 				<key>DYLIB_CURRENT_VERSION</key>
 				<string>1</string>
 				<key>SKIP_INSTALL</key>
-				<string>1</string>
+				<string>YES</string>
 			</dict>
 			<key>BuildPhases</key>
 			<array>


### PR DESCRIPTION
The Framework targets now use SKIP_INSTALL to allow for achieving. 
The universal script will now use the proper build directories based on the user preferences
