### PR TITLE
Fixes to header handling

### DIFF
--- a/Fake Framework/Templates/Framework & Library/Fake Static iOS Framework.xctemplate/TemplateInfo.plist
+++ b/Fake Framework/Templates/Framework & Library/Fake Static iOS Framework.xctemplate/TemplateInfo.plist
@@ -158,19 +158,19 @@ rm -rf "${UFW_OTHER_BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.embeddedframework"
 					<key>ShowEnvVarsInLog</key>
 					<string>false</string>
 					<key>ShellScript</key>
-					<string>INLINED_PYHON_SCRIPT="import sys; import os.path; headerPathFromFind = sys.argv[2]; srcRoot = sys.argv[1]; headerPathFromFindWithoutFilename = os.path.dirname( headerPathFromFind ); relatedPathForDirectory = os.path.relpath( headerPathFromFindWithoutFilename, srcRoot ); print( relatedPathForDirectory );"
+					<string>INLINED_PYTHON_SCRIPT="import sys; import os.path; headerPathFromFind = sys.argv[2]; srcRoot = sys.argv[1]; headerPathFromFindWithoutFilename = os.path.dirname( headerPathFromFind ); relatedPathForDirectory = os.path.relpath( headerPathFromFindWithoutFilename, srcRoot ); print( relatedPathForDirectory );"
 
 HEADERS_ROOT=$SRCROOT/$PRODUCT_NAME
-FRAMEWORK_HEADERS_DIR="$BUILT_PRODUCTS_DIR/$WRAPPER_NAME/Headers"
+FRAMEWORK_HEADERS_DIR="$BUILT_PRODUCTS_DIR/$WRAPPER_NAME/Versions/$FRAMEWORK_VERSION/Headers"
 
 ## only header files expected at this point
-PUBLIC_HEADERS=$( ls -1 "$FRAMEWORK_HEADERS_DIR" )
+PUBLIC_HEADERS=$( ls -1 "$FRAMEWORK_HEADERS_DIR" 2> /dev/null )
 
 
 for PUBLIC_HEADER in $PUBLIC_HEADERS; do
 
    FIND_RESULT=$( find "$HEADERS_ROOT" -name "$PUBLIC_HEADER" )
-   RELATIVE_PATH=$( python -c "$INLINED_PYHON_SCRIPT" "$HEADERS_ROOT" "$FIND_RESULT" )
+   RELATIVE_PATH=$( python -c "$INLINED_PYTHON_SCRIPT" "$HEADERS_ROOT" "$FIND_RESULT" )
 
    mkdir -p "$FRAMEWORK_HEADERS_DIR/$RELATIVE_PATH"
    mv "$FRAMEWORK_HEADERS_DIR/$PUBLIC_HEADER" "$FRAMEWORK_HEADERS_DIR/$RELATIVE_PATH/$PUBLIC_HEADER"

--- a/Real Framework/Templates/Framework & Library/Static iOS Framework.xctemplate/TemplateInfo.plist
+++ b/Real Framework/Templates/Framework & Library/Static iOS Framework.xctemplate/TemplateInfo.plist
@@ -152,19 +152,19 @@ fi
 					<key>ShowEnvVarsInLog</key>
 					<string>false</string>
 					<key>ShellScript</key>
-					<string>INLINED_PYHON_SCRIPT="import sys; import os.path; headerPathFromFind = sys.argv[2]; srcRoot = sys.argv[1]; headerPathFromFindWithoutFilename = os.path.dirname( headerPathFromFind ); relatedPathForDirectory = os.path.relpath( headerPathFromFindWithoutFilename, srcRoot ); print( relatedPathForDirectory );"
+					<string>INLINED_PYTHON_SCRIPT="import sys; import os.path; headerPathFromFind = sys.argv[2]; srcRoot = sys.argv[1]; headerPathFromFindWithoutFilename = os.path.dirname( headerPathFromFind ); relatedPathForDirectory = os.path.relpath( headerPathFromFindWithoutFilename, srcRoot ); print( relatedPathForDirectory );"
 
 HEADERS_ROOT=$SRCROOT/$PRODUCT_NAME
-FRAMEWORK_HEADERS_DIR="$BUILT_PRODUCTS_DIR/$WRAPPER_NAME/Headers"
+FRAMEWORK_HEADERS_DIR="$BUILT_PRODUCTS_DIR/$WRAPPER_NAME/Versions/$FRAMEWORK_VERSION/Headers"
 
 ## only header files expected at this point
-PUBLIC_HEADERS=$( ls -1 "$FRAMEWORK_HEADERS_DIR" )
+PUBLIC_HEADERS=$( ls -1 "$FRAMEWORK_HEADERS_DIR" 2> /dev/null )
 
 
 for PUBLIC_HEADER in $PUBLIC_HEADERS; do
 
    FIND_RESULT=$( find "$HEADERS_ROOT" -name "$PUBLIC_HEADER" )
-   RELATIVE_PATH=$( python -c "$INLINED_PYHON_SCRIPT" "$HEADERS_ROOT" "$FIND_RESULT" )
+   RELATIVE_PATH=$( python -c "$INLINED_PYTHON_SCRIPT" "$HEADERS_ROOT" "$FIND_RESULT" )
 
    mkdir -p "$FRAMEWORK_HEADERS_DIR/$RELATIVE_PATH"
    mv "$FRAMEWORK_HEADERS_DIR/$PUBLIC_HEADER" "$FRAMEWORK_HEADERS_DIR/$RELATIVE_PATH/$PUBLIC_HEADER"


### PR DESCRIPTION
Set FRAMEWORK_HEADERS_DIR to Versions/$FRAMEWORK_VERSION/Headers, fixes subdir header processing with the first build run
Build fix if no headers found
Rename INLINED_PYHON_SCRIPT
