### PR TITLE
Version "A" folder dependency

### DIFF
--- a/Fake Framework/Templates/Framework & Library/Fake Static iOS Framework.xctemplate/TemplateInfo.plist
+++ b/Fake Framework/Templates/Framework & Library/Fake Static iOS Framework.xctemplate/TemplateInfo.plist
@@ -297,8 +297,8 @@ mv "${BUILT_PRODUCTS_DIR}/${EXECUTABLE_PATH}.temp" "${BUILT_PRODUCTS_DIR}/${EXEC
 
 echo "Build symlinks"
 
-echo ln -sfh A "${BUILT_PRODUCTS_DIR}/${WRAPPER_NAME}/Versions/Current"
-ln -sfh A "${BUILT_PRODUCTS_DIR}/${WRAPPER_NAME}/Versions/Current"
+echo ln -sfh $FRAMEWORK_VERSION "${BUILT_PRODUCTS_DIR}/${WRAPPER_NAME}/Versions/Current"
+ln -sfh $FRAMEWORK_VERSION "${BUILT_PRODUCTS_DIR}/${WRAPPER_NAME}/Versions/Current"
 echo ln -sfh Versions/Current/Headers "${BUILT_PRODUCTS_DIR}/${WRAPPER_NAME}/Headers"
 ln -sfh Versions/Current/Headers "${BUILT_PRODUCTS_DIR}/${WRAPPER_NAME}/Headers"
 echo ln -sfh Versions/Current/Resources "${BUILT_PRODUCTS_DIR}/${WRAPPER_NAME}/Resources"


### PR DESCRIPTION
A couple of the lines in the scripts included a hard-coded reference to the version "A" folder.  Thus I changed it to correctly reference the actual $FRAMEWORK_VERSION variable.

Commit log:
Removed dependency on the hardcoded "A" version

PS- I absolutely love this framework :)
