### PR TITLE
Fix embeddedframework "Create product structure" build fail with xcode5.

### DIFF
--- a/devel/src/BuildFW.py
+++ b/devel/src/BuildFW.py
@@ -460,7 +460,7 @@ def ensure_parent_exists(path):
 #
 def remove_path(path):
     if os.path.exists(path):
-        if os.path.isdir(path):
+        if os.path.isdir(path) and not os.path.islink(path):
             shutil.rmtree(path)
         else:
             os.remove(path)
@@ -706,9 +706,17 @@ def build_embedded_framework(project):
     fw_path = project.local_built_fw_path
     embedded_path = project.local_built_embedded_fw_path
     fw_name = os.environ['WRAPPER_NAME']
-    remove_path(embedded_path)
-    ensure_path_exists(embedded_path)
-    copy_overwrite(fw_path, os.path.join(embedded_path, fw_name))
+
+    if (os.path.islink(fw_path)):
+        # If the framework path is a link, the build result already in embeddedframework.
+        # Just recreate embeddedframework's Resources
+        remove_path(os.path.join(embedded_path, "Resources"))
+    else:
+        remove_path(embedded_path)
+        ensure_path_exists(embedded_path)
+        copy_overwrite(fw_path, os.path.join(embedded_path, fw_name))
+
+    # Create embeddedframework's Resources        
     ensure_path_exists(os.path.join(embedded_path, "Resources"))
     symlink_source = os.path.join("..", fw_name, "Resources")
     symlink_path = os.path.join(embedded_path, "Resources")


### PR DESCRIPTION
It is a logic error in creating embeddedframework structure.

In build_embedded_framework function, the script removes the embeddedframework path at first and create a new one. After that it copies xxx.framework to embededframework folder. But at the second time of building, xxx.framework is only a link. The real data is in embeddedframework. If embeddedframework path is removed first, the result data is gone and link becomes invalid. Then the copy action is failed and an invalid link of xxx.framework left which will cause "create product structure" error during afterward builds.

If invalid xxx.framework link is already exist, it must be removed manually.
