### PR TITLE
Adds support for compiled storyboards in embeddedframework

### DIFF
--- a/Fake Framework/Templates/Framework & Library/Fake Static iOS Framework.xctemplate/TemplateInfo.plist
+++ b/Fake Framework/Templates/Framework & Library/Fake Static iOS Framework.xctemplate/TemplateInfo.plist
@@ -78,9 +78,10 @@
 					<string>false</string>
 					<key>ShellScript</key>
 					<string># TAG: BUILD SCRIPT (do not remove this comment)
-# Build script generated using https://github.com/kstenerud/iOS-Universal-Framework Mk 8 (beta 2012-06-16)
-import logging
+# Build script generated using https://github.com/ekilah/iOS-Universal-Framework - a fork of https://github.com/kstenerud/iOS-Universal-Framework Mk 8 (beta 2012-06-16)
+# Changes in this fork: Support for building an .embeddedframework with storyboards in the framework
 
+import logging
 
 ##############################################################################
 #
@@ -100,8 +101,8 @@ import logging
 #
 # If your framework contains no resources, choose 'framework'.
 #
-config_framework_type = 'framework'
-#config_framework_type = 'embeddedframework'
+#config_framework_type = 'framework'
+config_framework_type = 'embeddedframework'
 
 # Open the build directory in Finder when the universal framework is
 # successfully built.
@@ -544,12 +545,32 @@ def remove_path(path):
         else:
             os.remove(path)
 
-# Move a file or dir, replacing the destination if it exists.
+# Move a file (not a directory), replacing the destination if it exists.
 #
 def move_file(src, dst):
     if src == dst or not os.path.isfile(src):
         return
-    log.info("Move %s to %s" % (src, dst))
+    log.info("Move file %s to %s" % (src, dst))
+    ensure_parent_exists(dst)
+    remove_path(dst)
+    shutil.move(src, dst)
+
+# Move a directory (not a file), replacing the destination if it exists.
+#
+def move_dir(src, dst):
+    if src == dst or not os.path.isdir(src):
+        return
+    log.info("Move dir %s to %s" % (src, dst))
+    ensure_parent_exists(dst)
+    remove_path(dst)
+    shutil.move(src, dst)
+
+# Move a file OR directory, replacing the destination if it exists.
+#
+def move_file_or_dir(src, dst):
+    if src == dst or not os.path.exists(src):
+        return
+    log.info("Move file/dir %s to %s" % (src, dst))
     ensure_parent_exists(dst)
     remove_path(dst)
     shutil.move(src, dst)
@@ -678,6 +699,11 @@ def should_open_build_dir():
     env_setting = os.environ.get('UFW_OPEN_BUILD_DIR', None)
     if env_setting is not None:
         return env_setting
+    
+    # If building on Xcode Bots shouldn't open build directory.
+    build_user = os.environ['USER']
+    if build_user == '_teamsserver':
+        return False
 
     return config_open_build_dir
 
@@ -760,7 +786,8 @@ def add_symlinks_to_framework(project):
 # Build an embedded framework structure.
 # An embedded framework contains the actual framework, plus a "Resources"
 # directory containing symlinks to all resources found in the actual framework,
-# with the exception of "Info.plist" and anything ending in ".lproj":
+# with the exception of "Info.plist" and anything ending in ".lproj".
+# Also, compiled storyboards are not symlinked becuase iOS can't handle that - they are moved from the framework's Resources directory to the embeddedframework's Resources directory:
 #
 # MyFramework.embeddedframework
 # |-- MyFramework.framework
@@ -780,6 +807,7 @@ def add_symlinks_to_framework(project):
 # |       `-- Current -&gt; A
 # `-- Resources
 #     `-- MyViewController.nib -&gt; ../MyFramework.framework/Resources/MyViewController.nib
+#     -- MyStoryboard.storyboardc
 #
 def build_embedded_framework(project):
     fw_path = project.local_built_fw_path
@@ -800,8 +828,14 @@ def build_embedded_framework(project):
     symlink_source = os.path.join("..", fw_name, "Resources")
     symlink_path = os.path.join(embedded_path, "Resources")
     if os.path.isdir(os.path.join(fw_path, "Resources")):
-        for file in filter(lambda x: x != "Info.plist" and not x.endswith(".lproj"), os.listdir(os.path.join(fw_path, "Resources"))):
+        for file in filter(lambda x: x != "Info.plist" and not x.endswith(".lproj") and not x.endswith(".storyboardc"), os.listdir(os.path.join(fw_path, "Resources"))):
+            log.info("symlinking resource file: " + file)
             attempt_symlink(os.path.join(symlink_path, file), os.path.join(symlink_source, file))
+        for file in filter(lambda x: x.endswith(".storyboardc"), os.listdir(os.path.join(fw_path, "Resources"))):
+            src = os.path.join(embedded_path, fw_name, "Resources", file)
+            dst = os.path.join(symlink_path, file)
+            log.info("moving storyboard instead of symlinking it: " + file)
+            move_file_or_dir(src,dst) #storyboards are directories apparently
 
     # Remove the normal framework and replace it with a symlink to the copy
     # in the embedded framework. This is needed because Xcode runs its strip

--- a/Fake Framework/Templates/Framework & Library/Fake Static iOS Framework.xctemplate/TemplateInfo.plist
+++ b/Fake Framework/Templates/Framework & Library/Fake Static iOS Framework.xctemplate/TemplateInfo.plist
@@ -78,10 +78,9 @@
 					<string>false</string>
 					<key>ShellScript</key>
 					<string># TAG: BUILD SCRIPT (do not remove this comment)
-# Build script generated using https://github.com/ekilah/iOS-Universal-Framework - a fork of https://github.com/kstenerud/iOS-Universal-Framework Mk 8 (beta 2012-06-16)
-# Changes in this fork: Support for building an .embeddedframework with storyboards in the framework
-
+# Build script generated using https://github.com/kstenerud/iOS-Universal-Framework Mk 8 (beta 2012-06-16)
 import logging
+
 
 ##############################################################################
 #
@@ -101,8 +100,8 @@ import logging
 #
 # If your framework contains no resources, choose 'framework'.
 #
-#config_framework_type = 'framework'
-config_framework_type = 'embeddedframework'
+config_framework_type = 'framework'
+#config_framework_type = 'embeddedframework'
 
 # Open the build directory in Finder when the universal framework is
 # successfully built.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+###Fork notes
+This is a fork of https://github.com/kstenerud/iOS-Universal-Framework - a project to allow building so-called "embedded framework"s in Xcode (not the dynamic frameworks that iOS 8+ support, but the older way of including resources along with a static framework that has been around for much longer). 
+
+This fork adds support for including compiled Storyboard files in the `.embeddedframework` - the original repo is long dead because of these dynamic frameworks that Xcode now supports, but many people still use it. 
+
+Tested with Xcode 7.3.1 and the "Fake Framework" approach described in the repo (the original README is reproduced below).
+
+
 FINALLY!
 =======
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,3 @@
-###Fork notes
-This is a fork of https://github.com/kstenerud/iOS-Universal-Framework - a project to allow building so-called "embedded framework"s in Xcode (not the dynamic frameworks that iOS 8+ support, but the older way of including resources along with a static framework that has been around for much longer). 
-
-This fork adds support for including compiled Storyboard files in the `.embeddedframework` - the original repo is long dead because of these dynamic frameworks that Xcode now supports, but many people still use it. 
-
-Tested with Xcode 7.3.1 and the "Fake Framework" approach described in the repo (the original README is reproduced below).
-
-
 FINALLY!
 =======
 

--- a/Real Framework/Templates/Framework & Library/Static iOS Framework.xctemplate/TemplateInfo.plist
+++ b/Real Framework/Templates/Framework & Library/Static iOS Framework.xctemplate/TemplateInfo.plist
@@ -64,9 +64,10 @@
 					<string>false</string>
 					<key>ShellScript</key>
 					<string># TAG: BUILD SCRIPT (do not remove this comment)
-# Build script generated using https://github.com/kstenerud/iOS-Universal-Framework Mk 8 (beta 2012-06-16)
-import logging
+# Build script generated using https://github.com/ekilah/iOS-Universal-Framework - a fork of https://github.com/kstenerud/iOS-Universal-Framework Mk 8 (beta 2012-06-16)
+# Changes in this fork: Support for building an .embeddedframework with storyboards in the framework
 
+import logging
 
 ##############################################################################
 #
@@ -86,8 +87,8 @@ import logging
 #
 # If your framework contains no resources, choose 'framework'.
 #
-config_framework_type = 'framework'
-#config_framework_type = 'embeddedframework'
+#config_framework_type = 'framework'
+config_framework_type = 'embeddedframework'
 
 # Open the build directory in Finder when the universal framework is
 # successfully built.
@@ -530,12 +531,32 @@ def remove_path(path):
         else:
             os.remove(path)
 
-# Move a file or dir, replacing the destination if it exists.
+# Move a file (not a directory), replacing the destination if it exists.
 #
 def move_file(src, dst):
     if src == dst or not os.path.isfile(src):
         return
-    log.info("Move %s to %s" % (src, dst))
+    log.info("Move file %s to %s" % (src, dst))
+    ensure_parent_exists(dst)
+    remove_path(dst)
+    shutil.move(src, dst)
+
+# Move a directory (not a file), replacing the destination if it exists.
+#
+def move_dir(src, dst):
+    if src == dst or not os.path.isdir(src):
+        return
+    log.info("Move dir %s to %s" % (src, dst))
+    ensure_parent_exists(dst)
+    remove_path(dst)
+    shutil.move(src, dst)
+
+# Move a file OR directory, replacing the destination if it exists.
+#
+def move_file_or_dir(src, dst):
+    if src == dst or not os.path.exists(src):
+        return
+    log.info("Move file/dir %s to %s" % (src, dst))
     ensure_parent_exists(dst)
     remove_path(dst)
     shutil.move(src, dst)
@@ -664,6 +685,11 @@ def should_open_build_dir():
     env_setting = os.environ.get('UFW_OPEN_BUILD_DIR', None)
     if env_setting is not None:
         return env_setting
+    
+    # If building on Xcode Bots shouldn't open build directory.
+    build_user = os.environ['USER']
+    if build_user == '_teamsserver':
+        return False
 
     return config_open_build_dir
 
@@ -746,7 +772,8 @@ def add_symlinks_to_framework(project):
 # Build an embedded framework structure.
 # An embedded framework contains the actual framework, plus a "Resources"
 # directory containing symlinks to all resources found in the actual framework,
-# with the exception of "Info.plist" and anything ending in ".lproj":
+# with the exception of "Info.plist" and anything ending in ".lproj".
+# Also, compiled storyboards are not symlinked becuase iOS can't handle that - they are moved from the framework's Resources directory to the embeddedframework's Resources directory:
 #
 # MyFramework.embeddedframework
 # |-- MyFramework.framework
@@ -766,6 +793,7 @@ def add_symlinks_to_framework(project):
 # |       `-- Current -&gt; A
 # `-- Resources
 #     `-- MyViewController.nib -&gt; ../MyFramework.framework/Resources/MyViewController.nib
+#     -- MyStoryboard.storyboardc
 #
 def build_embedded_framework(project):
     fw_path = project.local_built_fw_path
@@ -786,8 +814,14 @@ def build_embedded_framework(project):
     symlink_source = os.path.join("..", fw_name, "Resources")
     symlink_path = os.path.join(embedded_path, "Resources")
     if os.path.isdir(os.path.join(fw_path, "Resources")):
-        for file in filter(lambda x: x != "Info.plist" and not x.endswith(".lproj"), os.listdir(os.path.join(fw_path, "Resources"))):
+        for file in filter(lambda x: x != "Info.plist" and not x.endswith(".lproj") and not x.endswith(".storyboardc"), os.listdir(os.path.join(fw_path, "Resources"))):
+            log.info("symlinking resource file: " + file)
             attempt_symlink(os.path.join(symlink_path, file), os.path.join(symlink_source, file))
+        for file in filter(lambda x: x.endswith(".storyboardc"), os.listdir(os.path.join(fw_path, "Resources"))):
+            src = os.path.join(embedded_path, fw_name, "Resources", file)
+            dst = os.path.join(symlink_path, file)
+            log.info("moving storyboard instead of symlinking it: " + file)
+            move_file_or_dir(src,dst) #storyboards are directories apparently
 
     # Remove the normal framework and replace it with a symlink to the copy
     # in the embedded framework. This is needed because Xcode runs its strip

--- a/Real Framework/Templates/Framework & Library/Static iOS Framework.xctemplate/TemplateInfo.plist
+++ b/Real Framework/Templates/Framework & Library/Static iOS Framework.xctemplate/TemplateInfo.plist
@@ -64,10 +64,9 @@
 					<string>false</string>
 					<key>ShellScript</key>
 					<string># TAG: BUILD SCRIPT (do not remove this comment)
-# Build script generated using https://github.com/ekilah/iOS-Universal-Framework - a fork of https://github.com/kstenerud/iOS-Universal-Framework Mk 8 (beta 2012-06-16)
-# Changes in this fork: Support for building an .embeddedframework with storyboards in the framework
-
+# Build script generated using https://github.com/kstenerud/iOS-Universal-Framework Mk 8 (beta 2012-06-16)
 import logging
+
 
 ##############################################################################
 #
@@ -87,8 +86,8 @@ import logging
 #
 # If your framework contains no resources, choose 'framework'.
 #
-#config_framework_type = 'framework'
-config_framework_type = 'embeddedframework'
+config_framework_type = 'framework'
+#config_framework_type = 'embeddedframework'
 
 # Open the build directory in Finder when the universal framework is
 # successfully built.

--- a/devel/src/BuildFW.py
+++ b/devel/src/BuildFW.py
@@ -1,7 +1,8 @@
 # TAG: BUILD SCRIPT (do not remove this comment)
-# Build script generated using https://github.com/kstenerud/iOS-Universal-Framework Mk 8 (beta 2012-06-16)
-import logging
+# Build script generated using https://github.com/ekilah/iOS-Universal-Framework - a fork of https://github.com/kstenerud/iOS-Universal-Framework Mk 8 (beta 2012-06-16)
+# Changes in this fork: Support for building an .embeddedframework with storyboards in the framework
 
+import logging
 
 ##############################################################################
 #
@@ -21,8 +22,8 @@ import logging
 #
 # If your framework contains no resources, choose 'framework'.
 #
-config_framework_type = 'framework'
-#config_framework_type = 'embeddedframework'
+#config_framework_type = 'framework'
+config_framework_type = 'embeddedframework'
 
 # Open the build directory in Finder when the universal framework is
 # successfully built.
@@ -465,12 +466,32 @@ def remove_path(path):
         else:
             os.remove(path)
 
-# Move a file or dir, replacing the destination if it exists.
+# Move a file (not a directory), replacing the destination if it exists.
 #
 def move_file(src, dst):
     if src == dst or not os.path.isfile(src):
         return
-    log.info("Move %s to %s" % (src, dst))
+    log.info("Move file %s to %s" % (src, dst))
+    ensure_parent_exists(dst)
+    remove_path(dst)
+    shutil.move(src, dst)
+
+# Move a directory (not a file), replacing the destination if it exists.
+#
+def move_dir(src, dst):
+    if src == dst or not os.path.isdir(src):
+        return
+    log.info("Move dir %s to %s" % (src, dst))
+    ensure_parent_exists(dst)
+    remove_path(dst)
+    shutil.move(src, dst)
+
+# Move a file OR directory, replacing the destination if it exists.
+#
+def move_file_or_dir(src, dst):
+    if src == dst or not os.path.exists(src):
+        return
+    log.info("Move file/dir %s to %s" % (src, dst))
     ensure_parent_exists(dst)
     remove_path(dst)
     shutil.move(src, dst)
@@ -686,7 +707,8 @@ def add_symlinks_to_framework(project):
 # Build an embedded framework structure.
 # An embedded framework contains the actual framework, plus a "Resources"
 # directory containing symlinks to all resources found in the actual framework,
-# with the exception of "Info.plist" and anything ending in ".lproj":
+# with the exception of "Info.plist" and anything ending in ".lproj".
+# Also, compiled storyboards are not symlinked becuase iOS can't handle that - they are moved from the framework's Resources directory to the embeddedframework's Resources directory:
 #
 # MyFramework.embeddedframework
 # |-- MyFramework.framework
@@ -706,6 +728,7 @@ def add_symlinks_to_framework(project):
 # |       `-- Current -> A
 # `-- Resources
 #     `-- MyViewController.nib -> ../MyFramework.framework/Resources/MyViewController.nib
+#     -- MyStoryboard.storyboardc
 #
 def build_embedded_framework(project):
     fw_path = project.local_built_fw_path
@@ -726,8 +749,14 @@ def build_embedded_framework(project):
     symlink_source = os.path.join("..", fw_name, "Resources")
     symlink_path = os.path.join(embedded_path, "Resources")
     if os.path.isdir(os.path.join(fw_path, "Resources")):
-        for file in filter(lambda x: x != "Info.plist" and not x.endswith(".lproj"), os.listdir(os.path.join(fw_path, "Resources"))):
+        for file in filter(lambda x: x != "Info.plist" and not x.endswith(".lproj") and not x.endswith(".storyboardc"), os.listdir(os.path.join(fw_path, "Resources"))):
+            log.info("symlinking resource file: " + file)
             attempt_symlink(os.path.join(symlink_path, file), os.path.join(symlink_source, file))
+        for file in filter(lambda x: x.endswith(".storyboardc"), os.listdir(os.path.join(fw_path, "Resources"))):
+            src = os.path.join(embedded_path, fw_name, "Resources", file)
+            dst = os.path.join(symlink_path, file)
+            log.info("moving storyboard instead of symlinking it: " + file)
+            move_file_or_dir(src,dst) #storyboards are directories apparently
 
     # Remove the normal framework and replace it with a symlink to the copy
     # in the embedded framework. This is needed because Xcode runs its strip

--- a/devel/src/BuildFW.py
+++ b/devel/src/BuildFW.py
@@ -1,8 +1,7 @@
 # TAG: BUILD SCRIPT (do not remove this comment)
-# Build script generated using https://github.com/ekilah/iOS-Universal-Framework - a fork of https://github.com/kstenerud/iOS-Universal-Framework Mk 8 (beta 2012-06-16)
-# Changes in this fork: Support for building an .embeddedframework with storyboards in the framework
-
+# Build script generated using https://github.com/kstenerud/iOS-Universal-Framework Mk 8 (beta 2012-06-16)
 import logging
+
 
 ##############################################################################
 #
@@ -22,8 +21,8 @@ import logging
 #
 # If your framework contains no resources, choose 'framework'.
 #
-#config_framework_type = 'framework'
-config_framework_type = 'embeddedframework'
+config_framework_type = 'framework'
+#config_framework_type = 'embeddedframework'
 
 # Open the build directory in Finder when the universal framework is
 # successfully built.


### PR DESCRIPTION
*Note:* I'm aware this project  is a bit abandoned, but I'm adding this PR so the issue gets some visibility and others may be able to utilize my solution for themselves (or improve it, if need be).

Tested with the "Fake Framework" approach.
Xcode 7.3.1 rejects an app install when an embeddedframework built with this tool (prior to my fix) is included in the project. The error is `App installation failed: Could not write to the device.`
The device logs complain about the symlink to the .storyboardc file being invalid as it attempts to install. The error is along the lines of `[MIFileManager realPathForURL:ifChildOfURL:]: Rejecting [embeddedframework/Resources/*.storyboardc] -> ../[.framework]/Resources/[*.storyboardc], as it is points outside or to the base`

Since the Resources inside the .framework file are not used, I chose to just move the .storyboardc out of the .framework and into the .embeddedframework's Resources directory (it used to symlink rather than be moved). This allows the app to install and run properly.

There may be another way to fix the symlink to iOS's liking that I don't know of - this was the first thing that worked for me.